### PR TITLE
Add unit tests for core data structures

### DIFF
--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'core' directory a Python package.

--- a/tests/core/test_chunk.py
+++ b/tests/core/test_chunk.py
@@ -1,0 +1,78 @@
+import unittest
+import uuid
+
+# Assuming the Chunk model is in src.models.chunk
+# Adjust the import path if necessary
+from src.forge_cli.core.chunk import Chunk
+
+class TestChunk(unittest.TestCase):
+
+    def test_chunk_instantiation_with_optional_fields(self):
+        """Test Chunk creation with all fields provided."""
+        chunk_id = str(uuid.uuid4())
+        content = "This is a test chunk."
+        index = 1
+        metadata = {"source": "test_document.txt"}
+        chunk = Chunk(
+            id=chunk_id,
+            content=content,
+            index=index,
+            metadata=metadata
+        )
+        self.assertEqual(chunk.id, chunk_id)
+        self.assertEqual(chunk.content, content)
+        self.assertEqual(chunk.index, index)
+        self.assertEqual(chunk.metadata, metadata)
+
+    def test_chunk_instantiation_without_optional_fields(self):
+        """Test Chunk creation with minimal fields and default ID."""
+        content = "Another test chunk."
+        # id, index, and metadata have defaults or are Optional
+        chunk = Chunk(content=content)
+
+        self.assertIsNotNone(chunk.id)
+        self.assertTrue(isinstance(uuid.UUID(chunk.id, version=4), uuid.UUID)) # Check if it's a valid UUIDv4
+        self.assertEqual(chunk.content, content)
+        self.assertIsNone(chunk.index) # Default for index is None
+        self.assertEqual(chunk.metadata, {}) # Default metadata should be empty dict
+
+    def test_chunk_metadata(self):
+        """Test the metadata field can store and retrieve arbitrary key-value pairs."""
+        content = "Chunk with metadata."
+        metadata = {"author": "John Doe", "page": 5, "active": True}
+        # Minimal instantiation, relying on default id and index
+        chunk = Chunk(content=content, metadata=metadata)
+
+        self.assertEqual(chunk.metadata["author"], "John Doe")
+        self.assertEqual(chunk.metadata["page"], 5)
+        self.assertTrue(chunk.metadata["active"])
+
+        # Pydantic models are generally mutable unless configured otherwise
+        chunk.metadata["new_key"] = "new_value"
+        self.assertEqual(chunk.metadata["new_key"], "new_value")
+
+        # Test with empty metadata
+        chunk_empty_meta = Chunk(content="content", metadata={})
+        self.assertEqual(chunk_empty_meta.metadata, {})
+
+        # Test with metadata being None (Pydantic uses the provided None, doesn't trigger default_factory)
+        chunk_none_meta = Chunk(content="content", metadata=None)
+        self.assertIsNone(chunk_none_meta.metadata)
+
+
+    def test_chunk_id_generation_and_usage(self):
+        """Test ID is generated if not provided, and used if provided."""
+        # ID generated (content is optional, but providing it for clarity)
+        chunk_generated_id = Chunk(content="content1")
+        self.assertIsNotNone(chunk_generated_id.id)
+        self.assertTrue(isinstance(uuid.UUID(chunk_generated_id.id, version=4), uuid.UUID))
+        self.assertIsNone(chunk_generated_id.index) # Check default
+
+        # ID provided
+        provided_id = str(uuid.uuid4())
+        chunk_provided_id = Chunk(id=provided_id, content="content2", index=0)
+        self.assertEqual(chunk_provided_id.id, provided_id)
+        self.assertEqual(chunk_provided_id.index, 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -1,0 +1,148 @@
+import unittest
+import uuid
+from datetime import datetime, timezone
+
+from src.forge_cli.core.document import Document
+from src.forge_cli.core.document_content import DocumentContent
+from src.forge_cli.core.chunk import Chunk
+
+class TestDocument(unittest.TestCase):
+
+    def test_instantiation_basic_required_fields(self):
+        """Test Document instantiation with required fields and default optionals."""
+        doc_id = str(uuid.uuid4())
+        md5 = "d41d8cd98f00b204e9800998ecf8427e" # example md5
+        mime = "text/plain"
+        doc_title = "My Test Document"
+
+        doc = Document(id=doc_id, md5sum=md5, mime_type=mime, title=doc_title)
+
+        self.assertEqual(doc.id, doc_id)
+        self.assertEqual(doc.md5sum, md5)
+        self.assertEqual(doc.mime_type, mime)
+        self.assertEqual(doc.title, doc_title)
+
+        self.assertIsNone(doc.author)
+        self.assertIsNone(doc.created_at)
+        self.assertIsNone(doc.updated_at)
+        self.assertIsNone(doc.url)
+        self.assertIsNone(doc.content)
+
+        self.assertEqual(doc.metadata, {})
+        self.assertIsInstance(doc.metadata, dict)
+        self.assertEqual(doc.vector_store_ids, [])
+        self.assertIsInstance(doc.vector_store_ids, list)
+
+    def test_instantiation_all_fields(self):
+        """Test Document creation with all fields provided."""
+        doc_id = str(uuid.uuid4())
+        md5 = "c3fce381355973c6fc6262b32f7a8a21"
+        mime = "application/pdf"
+        doc_title = "Comprehensive Document"
+
+        # Create a DocumentContent object
+        dc_id = "dc_content_id_001" # DocumentContent also requires an id
+        doc_content_obj = DocumentContent(
+            id=dc_id,
+            abstract="Abstract of content.",
+            segments=[Chunk(content="chunk in content")]
+        )
+
+        custom_metadata = {"category": "testing", "status": "draft"}
+        vector_ids = ["vs_1", "vs_2"]
+        now = datetime.now(timezone.utc)
+        specific_url = "https://example.com/document.pdf"
+        specific_author = "Test Author"
+
+        doc = Document(
+            id=doc_id,
+            md5sum=md5,
+            mime_type=mime,
+            title=doc_title,
+            author=specific_author,
+            created_at=now,
+            updated_at=now,
+            url=specific_url,
+            metadata=custom_metadata,
+            vector_store_ids=vector_ids,
+            content=doc_content_obj
+        )
+
+        self.assertEqual(doc.id, doc_id)
+        self.assertEqual(doc.md5sum, md5)
+        self.assertEqual(doc.mime_type, mime)
+        self.assertEqual(doc.title, doc_title)
+        self.assertEqual(doc.author, specific_author)
+        self.assertEqual(doc.created_at, now)
+        self.assertEqual(doc.updated_at, now)
+        self.assertEqual(doc.url, specific_url)
+        self.assertEqual(doc.metadata, custom_metadata)
+        self.assertEqual(doc.vector_store_ids, vector_ids)
+        self.assertIs(doc.content, doc_content_obj)
+        self.assertIsInstance(doc.content, DocumentContent)
+
+    def test_content_field_with_document_content(self):
+        """Test assigning a DocumentContent object to the 'content' field."""
+        doc_id = str(uuid.uuid4())
+        md5 = "b026324c6904b2a9cb4b88d6d61c81d1"
+        mime = "application/json"
+        doc_title = "Document with Content"
+
+        dc_id = "dc_for_doc_002" # DocumentContent requires an id
+        doc_content_obj = DocumentContent(id=dc_id, file_type="text/plain")
+
+        doc_with_content = Document(
+            id=doc_id, md5sum=md5, mime_type=mime, title=doc_title, content=doc_content_obj
+        )
+        self.assertIs(doc_with_content.content, doc_content_obj)
+        self.assertIsInstance(doc_with_content.content, DocumentContent)
+
+        # Test with content being None (which is its default)
+        doc_no_content = Document(
+            id=str(uuid.uuid4()), md5sum="another_md5", mime_type="text/xml", title="Doc No Content"
+        )
+        self.assertIsNone(doc_no_content.content)
+
+    def test_default_factories_for_metadata_and_vector_store_ids(self):
+        """Test default factory behaviors for metadata and vector_store_ids."""
+        doc_id = str(uuid.uuid4())
+        md5 = "6f1ed002ab5595859014ebf0951522d9"
+        mime = "image/png"
+        doc_title = "Document For Defaults Test"
+
+        doc = Document(id=doc_id, md5sum=md5, mime_type=mime, title=doc_title)
+
+        self.assertEqual(doc.metadata, {})
+        self.assertIsInstance(doc.metadata, dict)
+        self.assertEqual(doc.vector_store_ids, [])
+        self.assertIsInstance(doc.vector_store_ids, list)
+
+    def test_datetime_fields_created_updated_at(self):
+        """Test the behavior of created_at and updated_at fields."""
+        doc_id = str(uuid.uuid4())
+        md5 = "098f6bcd4621d373cade4e832627b4f6"
+        mime = "text/calendar"
+        doc_title = "Datetime Test Doc"
+
+        # Test when not provided (should be None)
+        doc_no_dt = Document(id=doc_id, md5sum=md5, mime_type=mime, title=doc_title)
+        self.assertIsNone(doc_no_dt.created_at)
+        self.assertIsNone(doc_no_dt.updated_at)
+
+        # Test providing specific datetimes
+        specific_created_at = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        specific_updated_at = datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+        doc_specific_dt = Document(
+            id=str(uuid.uuid4()),
+            md5sum="anothermd5",
+            mime_type=mime,
+            title="Specific DT Doc",
+            created_at=specific_created_at,
+            updated_at=specific_updated_at
+        )
+        self.assertEqual(doc_specific_dt.created_at, specific_created_at)
+        self.assertEqual(doc_specific_dt.updated_at, specific_updated_at)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_document_content.py
+++ b/tests/core/test_document_content.py
@@ -1,0 +1,120 @@
+import unittest
+import uuid
+
+from src.forge_cli.core.document_content import DocumentContent
+from src.forge_cli.core.chunk import Chunk
+from src.forge_cli.core.page import Page
+
+class TestDocumentContent(unittest.TestCase):
+
+    def test_instantiation_basic_required_id(self):
+        """Test DocumentContent instantiation with required 'id' and default optionals."""
+        doc_id = "test_id_123" # Must be provided
+
+        dc = DocumentContent(id=doc_id)
+
+        self.assertEqual(dc.id, doc_id)
+        self.assertIsNone(dc.abstract)
+        self.assertIsNone(dc.summary)
+        self.assertIsNone(dc.outline)
+        self.assertEqual(dc.keywords, [])
+        self.assertIsInstance(dc.keywords, list)
+        self.assertIsNone(dc.language)
+        self.assertIsNone(dc.page_count)
+        self.assertIsNone(dc.file_type)
+        self.assertIsNone(dc.encoding)
+        self.assertEqual(dc.metadata, {})
+        self.assertIsInstance(dc.metadata, dict)
+        self.assertEqual(dc.segments, [])
+        self.assertIsInstance(dc.segments, list)
+
+    def test_instantiation_all_fields(self):
+        """Test DocumentContent creation with all fields provided."""
+        doc_id = str(uuid.uuid4()) # Example of a generated ID, but must be passed
+        chunk1 = Chunk(content="First chunk")
+        page1 = Page(url="https://example.com/page1", content="Page content")
+
+        dc = DocumentContent(
+            id=doc_id,
+            abstract="This is an abstract.",
+            summary="This is a summary.",
+            outline="1. Point one\n2. Point two",
+            keywords=["test", "document", "example"],
+            language="en",
+            page_count=5,
+            file_type="application/pdf",
+            encoding="UTF-8",
+            metadata={"source": "upload", "version": "1.0"},
+            segments=[chunk1, page1]
+        )
+
+        self.assertEqual(dc.id, doc_id)
+        self.assertEqual(dc.abstract, "This is an abstract.")
+        self.assertEqual(dc.summary, "This is a summary.")
+        self.assertEqual(dc.outline, "1. Point one\n2. Point two")
+        self.assertEqual(dc.keywords, ["test", "document", "example"])
+        self.assertEqual(dc.language, "en")
+        self.assertEqual(dc.page_count, 5)
+        self.assertEqual(dc.file_type, "application/pdf")
+        self.assertEqual(dc.encoding, "UTF-8")
+        self.assertEqual(dc.metadata, {"source": "upload", "version": "1.0"})
+        self.assertEqual(len(dc.segments), 2)
+        self.assertIs(dc.segments[0], chunk1)
+        self.assertIs(dc.segments[1], page1)
+
+    def test_segments_field_mixed_types(self):
+        """Test the 'segments' field can correctly hold Page and Chunk objects."""
+        doc_id = "segments_test_doc"
+        chunk1 = Chunk(content="Generic chunk data")
+        page1 = Page(url="https://example.com/page1", content="Content of page 1")
+        chunk2 = Chunk(id=str(uuid.uuid4()), content="Another chunk")
+
+        dc = DocumentContent(id=doc_id, segments=[chunk1, page1, chunk2])
+
+        self.assertEqual(dc.id, doc_id)
+        self.assertEqual(len(dc.segments), 3)
+        self.assertIs(dc.segments[0], chunk1)
+        self.assertIsInstance(dc.segments[0], Chunk)
+        self.assertIs(dc.segments[1], page1)
+        self.assertIsInstance(dc.segments[1], Page)
+        self.assertIs(dc.segments[2], chunk2)
+        self.assertIsInstance(dc.segments[2], Chunk)
+
+    def test_default_factories_for_keywords_metadata_segments(self):
+        """Test default factory behaviors for keywords, metadata, and segments."""
+        doc_id = "defaults_test_doc"
+
+        # Instantiated with only the required 'id'
+        dc = DocumentContent(id=doc_id)
+
+        self.assertEqual(dc.keywords, [])
+        self.assertIsInstance(dc.keywords, list)
+
+        self.assertEqual(dc.metadata, {})
+        self.assertIsInstance(dc.metadata, dict)
+
+        self.assertEqual(dc.segments, [])
+        self.assertIsInstance(dc.segments, list)
+
+    def test_optional_fields_can_be_none_or_set(self):
+        """Test that optional fields can be None or be set with values."""
+        doc_id = "optional_fields_test"
+
+        # Initial instantiation (all optionals should be None or default)
+        dc1 = DocumentContent(id=doc_id)
+        self.assertIsNone(dc1.abstract)
+        self.assertIsNone(dc1.file_type)
+
+        # Setting some optional fields
+        dc2 = DocumentContent(
+            id=doc_id,
+            abstract="Test Abstract",
+            file_type="text/markdown",
+            language="fr"
+        )
+        self.assertEqual(dc2.abstract, "Test Abstract")
+        self.assertEqual(dc2.file_type, "text/markdown")
+        self.assertEqual(dc2.language, "fr")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_page.py
+++ b/tests/core/test_page.py
@@ -1,0 +1,83 @@
+import unittest
+import uuid
+
+# Assuming the Page model is in src.forge_cli.core.page
+# Adjust the import path if necessary
+from src.forge_cli.core.page import Page
+from src.forge_cli.core.chunk import Chunk # To compare behavior or check instance
+
+class TestPage(unittest.TestCase):
+
+    def test_page_instantiation_with_specific_and_inherited_fields(self):
+        """Test Page creation with its specific fields and inherited Chunk fields."""
+        page_id = str(uuid.uuid4())
+        content = "This is the content of a page."
+        url = "https://example.com/my-page"
+        metadata = {"source": "web"}
+        index = 0
+
+        page = Page(
+            id=page_id,
+            content=content,
+            url=url,
+            metadata=metadata,
+            index=index
+        )
+
+        self.assertEqual(page.id, page_id)
+        self.assertEqual(page.content, content)
+        self.assertEqual(page.url, url)
+        self.assertEqual(page.metadata, metadata)
+        self.assertEqual(page.index, index)
+        self.assertTrue(isinstance(page, Chunk)) # Verify inheritance
+
+    def test_page_instantiation_minimal(self):
+        """Test Page creation with minimal fields (assuming url is key)."""
+        # This test depends on knowing which fields are truly optional or required for Page
+        # For now, let's assume 'url' is a primary specific field.
+        # And 'content' might be optional in Chunk, 'id' has default factory.
+        url = "https://example.com/another-page"
+        page = Page(url=url) # Potentially add other fields if instantiation fails
+
+        self.assertIsNotNone(page.id) # Inherited from Chunk
+        self.assertTrue(isinstance(uuid.UUID(page.id, version=4), uuid.UUID))
+        self.assertEqual(page.url, url)
+        self.assertIsNone(page.content) # Default from Chunk
+        self.assertEqual(page.metadata, {}) # Default from Chunk
+        self.assertIsNone(page.index) # Default from Chunk
+
+    def test_page_url_field(self):
+        """Test the Page-specific 'url' field."""
+        url1 = "https://example.com/page1"
+        page1 = Page(url=url1, content="Content for page 1")
+        self.assertEqual(page1.url, url1)
+
+        # Test with a different URL
+        url2 = "http://sub.example.org/another/path?query=true"
+        page2 = Page(url=url2)
+        self.assertEqual(page2.url, url2)
+
+    def test_page_inherits_chunk_id_generation(self):
+        """Test that Page instances correctly use Chunk's id generation."""
+        page = Page(url="https://example.com/test-id-gen")
+        self.assertIsNotNone(page.id)
+        self.assertTrue(isinstance(uuid.UUID(page.id, version=4), uuid.UUID))
+
+        # Test providing an ID
+        specific_id = str(uuid.uuid4())
+        page_with_id = Page(id=specific_id, url="https://example.com/specific-id")
+        self.assertEqual(page_with_id.id, specific_id)
+
+    def test_page_inherits_chunk_metadata_default(self):
+        """Test that Page instances correctly use Chunk's metadata default."""
+        page = Page(url="https://example.com/test-metadata")
+        self.assertIsNotNone(page.metadata)
+        self.assertEqual(page.metadata, {})
+
+        custom_metadata = {"key": "value"}
+        page_with_meta = Page(url="https://example.com/custom-meta", metadata=custom_metadata)
+        self.assertEqual(page_with_meta.metadata, custom_metadata)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces unit tests for the following core data structures:
- Chunk
- Page
- DocumentContent
- Document

The tests are located in the `tests/core` directory and cover basic instantiation, default values, and field assignments for these Pydantic models.

Note: I encountered some issues while trying to run these tests. It seems there were problems with Python paths, some missing dependencies (`aiohttp`, `loguru`, `openai`), and Python 3.10 typing compatibility in the existing `src/forge_cli/response/_types/` codebase. I attempted some fixes for the typing compatibility, but they weren't fully resolved. The new tests themselves should be correct, but I couldn't fully validate them.